### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: ./rust-lib
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install rust targets
         run: rustup target install x86_64-apple-darwin && rustup target install aarch64-apple-darwin
       - name: Clean environment
@@ -24,7 +24,7 @@ jobs:
       - name: Create rust macos universal lib
         run: lipo -create -output librust_lib.dylib target/x86_64-apple-darwin/release/librust_lib.dylib target/aarch64-apple-darwin/release/librust_lib.dylib
       - name: Upload rust macos universal lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: librust_lib.dylib
           path: ./rust-lib/librust_lib.dylib
@@ -35,7 +35,7 @@ jobs:
       run:
         working-directory: ./rust-lib
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install rust targets
         run: rustup target install x86_64-unknown-linux-gnu
       - name: Clean environment
@@ -43,7 +43,7 @@ jobs:
       - name: Build rust linux lib
         run: cargo build --release --target x86_64-unknown-linux-gnu
       - name: Upload rust linux lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: librust_lib.so
           path: ./rust-lib/target/x86_64-unknown-linux-gnu/release/librust_lib.so
@@ -54,7 +54,7 @@ jobs:
       run:
         working-directory: ./rust-lib
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install rust targets
         run: rustup target install x86_64-pc-windows-msvc
       - name: Clean environment
@@ -62,7 +62,7 @@ jobs:
       - name: Build rust windows lib
         run: cargo build --release --target x86_64-pc-windows-msvc
       - name: Upload rust windows lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rust_lib.dll
           path: ./rust-lib/target/x86_64-pc-windows-msvc/release/rust_lib.dll
@@ -78,24 +78,24 @@ jobs:
       run:
         working-directory: ./java-extension
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Download rust macos universal lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: librust_lib.dylib
           path: ./java-extension/src/main/resources/
       - name: Download rust linux lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: librust_lib.so
           path: ./java-extension/src/main/resources/
       - name: Download rust windows lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: rust_lib.dll
           path: ./java-extension/src/main/resources/
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -109,11 +109,11 @@ jobs:
       - name: Check version
         run: test -f build/libs/ic-burp-extension-${{ steps.get_version.outputs.version }}.jar
       - name: Create build attestation for jar
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-path: ./java-extension/build/libs/ic-burp-extension-${{ steps.get_version.outputs.version }}.jar
       - name: Upload jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ic-burp-extension-${{ steps.get_version.outputs.version }}.jar
           path: ./java-extension/build/libs/ic-burp-extension-${{ steps.get_version.outputs.version }}.jar

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 23d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `actions/download-artifact@v4` -> `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0`
  - Version: v4.3.0 | Latest: v3.1.0-node20 | Release age: 23d
  - Commit: https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `actions/setup-java@v4` -> `actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0`
  - Version: v4.8.0 | Latest: v5.2.0 | Release age: 77d
  - Commit: https://github.com/actions/setup-java/commit/c1e323688fd81a25caa38c78aa6df2d33d3e20d9

- `actions/attest-build-provenance@v1` -> `actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4`
  - Version: v1.4.4 | Latest: v4.1.0 | Release age: 41d
  - Commit: https://github.com/actions/attest-build-provenance/commit/ef244123eb79f2f7a7e75d99086184180e6d0018

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `actions/setup-java@v3` -> `actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1`
  - Version: v3.14.1 | Latest: v5.2.0 | Release age: 77d
  - Commit: https://github.com/actions/setup-java/commit/17f84c3641ba7b8f6deff6309fc4c864478f5d62


### Files modified

- `.github/workflows/release.yml`
- `.github/workflows/run-tests.yml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)