### PR TITLE
chore: Update CODEOWNERS: merge infrasec/prodsec into security team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dfinity/product-security
+* @dfinity/security


### PR DESCRIPTION
The infrasec and prodsec security teams have been merged into a single `security` team.

This PR updates CODEOWNERS to replace references to the old teams with the merged team:
- `@dfinity/infrasec` -> `@dfinity/security`
- `@dfinity/product-security` / `@dfinity/prodsec` -> `@dfinity/security`

Other owners, file paths, alignment and comments are preserved. Generated automatically.